### PR TITLE
remove redundant react-router package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
-    "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "redux": "^3.6.0",
     "redux-notifications": "^3.1.0",


### PR DESCRIPTION
react-router-dom re-exports all of react-router's exports, so  we need only import from react-router-dom


refer to this react-router issue: [what's the diff between `react-router-dom` & `react-router`? #4648](https://github.com/ReactTraining/react-router/issues/4648)