### PR TITLE
remove redundant react-router package

### DIFF
--- a/client/components/Common/Authorize.js
+++ b/client/components/Common/Authorize.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Redirect } from 'react-router'
+import { Redirect } from 'react-router-dom'
 import { logoutUser } from '../../redux/modules/user'
 import { bool, string, object, number, func } from 'prop-types'
 

--- a/client/components/Login/LoginForm.js
+++ b/client/components/Login/LoginForm.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Redirect } from 'react-router'
+import { Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { loginRequest } from '../../redux/modules/loginLocal'
 import Input from '../Common/Input'

--- a/client/components/Login/SetToken.js
+++ b/client/components/Login/SetToken.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { Redirect } from 'react-router'
+import { Redirect } from 'react-router-dom'
 import store from '../../redux/store'
 import { setUser } from '../../redux/modules/user'
 import prepareUserFromToken from '../../auth/prepareUserFromToken'

--- a/client/components/Router/CompiledRoutes.js
+++ b/client/components/Router/CompiledRoutes.js
@@ -8,7 +8,7 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactRouter = require('react-router');
+var _reactRouter = require('react-router-dom');
 
 var _Home = require('../Home/Home');
 

--- a/client/components/Router/Routes.js
+++ b/client/components/Router/Routes.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Switch } from 'react-router'
+import { Route, Switch } from 'react-router-dom'
 import Home from '../Home/Home'
 import Login from '../Login/Login'
 import Signup from '../Signup/Signup'

--- a/client/components/Router/Status.js
+++ b/client/components/Router/Status.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route } from 'react-router'
+import { Route } from 'react-router-dom'
 import { number, element } from 'prop-types'
 
 const Status = ({ code, children }) => (

--- a/client/components/Signup/SignupForm.js
+++ b/client/components/Signup/SignupForm.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-prop-types */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import { Redirect } from 'react-router'
+import { Redirect } from 'react-router-dom'
 import { signupRequest } from '../../redux/modules/signupLocal'
 import Input from '../Common/Input'
 import {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.4",
-    "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
     "redux": "^3.6.0",
     "redux-notifications": "^3.1.0",

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const fs = require('fs')
 // React
 const React = require('react')
 const ReactDOMServer = require('react-dom/server')
-const { StaticRouter } = require('react-router')
+const { StaticRouter } = require('react-router-dom')
 const { Provider } = require('react-redux')
 const { store } = process.env.NODE_ENV === 'production'
   ? require('./public/production/client/redux/store')


### PR DESCRIPTION
react-router-dom re-exports all of react-router's exports, so we need only import from react-router-dom

[refer to this react-router issue: what's the diff between react-router-dom & react-router? #4648](https://github.com/ReactTraining/react-router/issues/4648)